### PR TITLE
Update to 1.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "setuptools-rust" %}
-{% set version = "1.5.2" %}
+{% set version = "1.8.1" %}
 
 package:
   name: {{ name }}
@@ -7,24 +7,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/s/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d8daccb14dc0eae1b6b6eb3ecef79675bd37b4065369f79c35393dd5c55652c7
+  sha256: 94b1dd5d5308b3138d5b933c3a2b55e6d6927d1a22632e509fcea9ddd0f7e486
 
 build:
   number: 0
-  skip: True # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: True # [py<38]
+  script: {{ PYTHON }} -m pip install --no-deps . -vv --no-build-isolation
 
 requirements:
   host:
     - pip
     - python
     - setuptools >=62.4
+    - setuptools_scm
     - wheel
   run:
     - python
     - semantic_version >=2.8.2,<3
     - setuptools >=62.4
-    - typing_extensions >=3.7.4.3
+    - tomli >=1.2.1  # [py<311]
 
 test:
   imports:
@@ -39,14 +40,12 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://github.com/PyO3/setuptools-rust/blob/v{{ version }}/LICENSE
   summary: Setuptools rust extension plugin
   description: |
     setuptools-rust is a plugin for setuptools to build Rust Python extensions implemented with PyO3 or rust-cpython.
     Compile and distribute Python extensions written in Rust as easily as if they were written in C.
   dev_url: https://github.com/PyO3/setuptools-rust
   doc_url: https://setuptools-rust.readthedocs.io/
-  doc_source_url: https://github.com/PyO3/setuptools-rust/tree/v{{ version }}/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
### setuptools-rust 1.8.1

**Destination channel:** {defaults}

### Links

- [PKG-4025](https://anaconda.atlassian.net/browse/PKG-4025) 
- [Upstream repository](https://github.com/PyO3/setuptools-rust/tree/release-1.8.1)
- [Upstream changelog/diff](https://github.com/PyO3/setuptools-rust/releases)
- Relevant dependency PRs:
  - This PR is needed for `cryptography 42.0.0` [Jira ticket](https://anaconda.atlassian.net/browse/PKG-4018)

### Explanation of changes:

- Updated `version`, `sha256`, and dependencies
- Added `--no-deps` and `--no-build-isolation`
- Removed `license_url` and `doc_source_url` as `license_file` and `doc_url` are being used


[PKG-4025]: https://anaconda.atlassian.net/browse/PKG-4025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ